### PR TITLE
Added autoload for airline theme.

### DIFF
--- a/autoload/airline/themes/Revolution.vim
+++ b/autoload/airline/themes/Revolution.vim
@@ -1,0 +1,102 @@
+" Each theme is contained in its own file and declares variables scoped to the
+" file.  These variables represent the possible "modes" that airline can
+" detect.  The mode is the return value of mode(), which gets converted to a
+" readable string.  The following is a list currently supported modes: normal,
+" insert, replace, visual, and inactive.
+"
+" Each mode can also have overrides.  These are small changes to the mode that
+" don't require a completely different look.  "modified" and "paste" are two
+" such supported overrides.  These are simply suffixed to the major mode,
+" separated by an underscore.  For example, "normal_modified" would be normal
+" mode where the current buffer is modified.
+"
+" The theming algorithm is a 2-pass system where the mode will draw over all
+" parts of the statusline, and then the override is applied after.  This means
+" it is possible to specify a subset of the theme in overrides, as it will
+" simply overwrite the previous colors.  If you want simultaneous overrides,
+" then they will need to change different parts of the statusline so they do
+" not conflict with each other.
+"
+" First, let's define an empty dictionary and assign it to the "palette"
+" variable. The # is a separator that maps with the directory structure. If
+" you get this wrong, Vim will complain loudly.
+let g:airline#themes#Revolution#palette = {}
+
+" First let's define some arrays. The s: is just a VimL thing for scoping the
+" variables to the current script. Without this, these variables would be
+" declared globally. Now let's declare some colors for normal mode and add it
+" to the dictionary.  The array is in the format:
+" [ guifg, guibg, ctermfg, ctermbg, opts ]. See "help attr-list" for valid
+" values for the "opt" value.
+let s:N1   = [ '#00005f' , '#dfff00' , 17  , 190 ]
+let s:N2   = [ '#ffffff' , '#444444' , 255 , 238 ]
+let s:N3   = [ '#9cffd3' , '#202020' , 85  , 234 ]
+let g:airline#themes#Revolution#palette.normal = airline#themes#generate_color_map(s:N1, s:N2, s:N3)
+
+" Here we define overrides for when the buffer is modified.  This will be
+" applied after g:airline#themes#dark#palette.normal, hence why only certain keys are
+" declared.
+let g:airline#themes#Revolution#palette.normal_modified = {
+      \ 'airline_c': [ '#ffffff' , '#5f005f' , 255     , 53      , ''     ] ,
+      \ }
+
+
+let s:I1 = [ '#00005f' , '#00dfff' , 17  , 45  ]
+let s:I2 = [ '#ffffff' , '#005fff' , 255 , 27  ]
+let s:I3 = [ '#ffffff' , '#000080' , 15  , 17  ]
+let g:airline#themes#Revolution#palette.insert = airline#themes#generate_color_map(s:I1, s:I2, s:I3)
+let g:airline#themes#Revolution#palette.insert_modified = {
+      \ 'airline_c': [ '#ffffff' , '#5f005f' , 255     , 53      , ''     ] ,
+      \ }
+let g:airline#themes#Revolution#palette.insert_paste = {
+      \ 'airline_a': [ s:I1[0]   , '#d78700' , s:I1[2] , 172     , ''     ] ,
+      \ }
+
+
+let g:airline#themes#Revolution#palette.replace = copy(g:airline#themes#dark#palette.insert)
+let g:airline#themes#Revolution#palette.replace.airline_a = [ s:I2[0]   , '#af0000' , s:I2[2] , 124     , ''     ]
+let g:airline#themes#Revolution#palette.replace_modified = g:airline#themes#dark#palette.insert_modified
+
+
+let s:V1 = [ '#000000' , '#ffaf00' , 232 , 214 ]
+let s:V2 = [ '#000000' , '#ff5f00' , 232 , 202 ]
+let s:V3 = [ '#ffffff' , '#5f0000' , 15  , 52  ]
+let g:airline#themes#Revolution#palette.visual = airline#themes#generate_color_map(s:V1, s:V2, s:V3)
+let g:airline#themes#Revolution#palette.visual_modified = {
+      \ 'airline_c': [ '#ffffff' , '#5f005f' , 255     , 53      , ''     ] ,
+      \ }
+
+
+let s:IA1 = [ '#4e4e4e' , '#1c1c1c' , 239 , 234 , '' ]
+let s:IA2 = [ '#4e4e4e' , '#262626' , 239 , 235 , '' ]
+let s:IA3 = [ '#4e4e4e' , '#303030' , 239 , 236 , '' ]
+let g:airline#themes#Revolution#palette.inactive = airline#themes#generate_color_map(s:IA1, s:IA2, s:IA3)
+let g:airline#themes#Revolution#palette.inactive_modified = {
+      \ 'airline_c': [ '#875faf' , '' , 97 , '' , '' ] ,
+      \ }
+
+
+" Accents are used to give parts within a section a slightly different look or
+" color. Here we are defining a "red" accent, which is used by the 'readonly'
+" part by default. Only the foreground colors are specified, so the background
+" colors are automatically extracted from the underlying section colors. What
+" this means is that regardless of which section the part is defined in, it
+" will be red instead of the section's foreground color. You can also have
+" multiple parts with accents within a section.
+let g:airline#themes#Revolution#palette.accents = {
+      \ 'red': [ '#ff0000' , '' , 160 , ''  ]
+      \ }
+
+
+" Here we define the color map for ctrlp.  We check for the g:loaded_ctrlp
+" variable so that related functionality is loaded iff the user is using
+" ctrlp. Note that this is optional, and if you do not define ctrlp colors
+" they will be chosen automatically from the existing palette.
+if !get(g:, 'loaded_ctrlp', 0)
+  finish
+endif
+let g:airline#themes#Revolution#palette.ctrlp = airline#extensions#ctrlp#generate_color_map(
+      \ [ '#d7d7ff' , '#5f00af' , 189 , 55  , ''     ],
+      \ [ '#ffffff' , '#875fd7' , 231 , 98  , ''     ],
+      \ [ '#5f00af' , '#ffffff' , 55  , 231 , 'bold' ])
+

--- a/autoload/airline/themes/Revolution.vim
+++ b/autoload/airline/themes/Revolution.vim
@@ -21,6 +21,7 @@
 " variable. The # is a separator that maps with the directory structure. If
 " you get this wrong, Vim will complain loudly.
 let g:airline#themes#Revolution#palette = {}
+let g:colors_name = 'Revolution'
 
 " First let's define some arrays. The s: is just a VimL thing for scoping the
 " variables to the current script. Without this, these variables would be
@@ -99,4 +100,3 @@ let g:airline#themes#Revolution#palette.ctrlp = airline#extensions#ctrlp#generat
       \ [ '#d7d7ff' , '#5f00af' , 189 , 55  , ''     ],
       \ [ '#ffffff' , '#875fd7' , 231 , 98  , ''     ],
       \ [ '#5f00af' , '#ffffff' , 55  , 231 , 'bold' ])
-

--- a/colors/Revolution.vim
+++ b/colors/Revolution.vim
@@ -1,102 +1,280 @@
-" Vim color file - Revolution
+"" Vim color file - Revolution
+"set background=dark
+"if version > 580
+	"hi clear
+	"if exists("syntax_on")
+		"syntax reset
+	"endif
+"endif
+
+"set t_Co=256
+"let g:colors_name = "Revolution"
+
+hi clear
+if exists('syntax on') | syntax reset | endif
 set background=dark
-if version > 580
-	hi clear
-	if exists("syntax_on")
-		syntax reset
-	endif
-endif
+let g:colors_name = 'Revolution'
 
-set t_Co=256
-let g:colors_name = "Revolution"
+" Execute the 'highlight' command with a List of arguments.
+function! s:Highlight(args)
+  exec 'highlight ' . join(a:args, ' ')
+endfunction
 
-hi IncSearch guifg=#bdae88 guibg=#492224 guisp=#492224 gui=NONE ctermfg=144 ctermbg=52 cterm=NONE
-hi WildMenu guifg=NONE guibg=#A1A6A8 guisp=#A1A6A8 gui=NONE ctermfg=NONE ctermbg=248 cterm=NONE
-hi SignColumn guifg=#192224 guibg=#536991 guisp=#536991 gui=NONE ctermfg=235 ctermbg=60 cterm=NONE
+function! s:AddGroundValues(accumulator, ground, color)
+  let new_list = a:accumulator
+  for [where, value] in items(a:color)
+    call add(new_list, where . a:ground . '=' . value)
+  endfor
+
+  return new_list
+endfunction
+
+function! s:Col(group, fg_name, ...)
+  " ... = optional bg_name
+
+  let pieces = [a:group]
+
+  if a:fg_name !=# ''
+    let pieces = s:AddGroundValues(pieces, 'fg', s:colors[a:fg_name])
+  endif
+
+  if a:0 > 0 && a:1 !=# ''
+    let pieces = s:AddGroundValues(pieces, 'bg', s:colors[a:1])
+  endif
+
+  call s:Clear(a:group)
+  call s:Highlight(pieces)
+endfunction
+
+function! s:Attr(group, attr)
+  let l:attrs = [a:group, 'term=' . a:attr, 'cterm=' . a:attr, 'gui=' . a:attr]
+  call s:Highlight(l:attrs)
+endfunction
+
+function! s:Clear(group)
+  exec 'highlight clear ' . a:group
+endfunction
+
+
+" Colors ======================================================================
+
+" Let's store all the colors in a dictionary.
+let s:colors = {}
+
+" Base colors
+let s:colors.base0  = { 'gui': '#bdae88', 'cterm': 144 }
+let s:colors.base1  = { 'gui': '#492224', 'cterm':  52 }
+let s:colors.base2  = { 'gui': '#a1a6a8', 'cterm': 248 }
+let s:colors.base3  = { 'gui': '#192224', 'cterm': 235 }
+let s:colors.base4  = { 'gui': '#bd9800', 'cterm':   1 }
+let s:colors.base5  = { 'gui': '#536991', 'cterm':  60 }
+let s:colors.base6  = { 'gui': '#b5b5b5', 'cterm': 249 }
+let s:colors.base7  = { 'gui': '#965b3f', 'cterm': 137 }
+let s:colors.base8  = { 'gui': '#4b4b4b', 'cterm': 239 }
+let s:colors.base10 = { 'gui': '#536c70', 'cterm':  66 }
+let s:colors.base11 = { 'gui': '#cfcfcf', 'cterm': 252 }
+let s:colors.base12 = { 'gui': '#a33202', 'cterm': 130 }
+let s:colors.base13 = { 'gui': '#ff0d0d', 'cterm': 196 }
+let s:colors.base14 = { 'gui': '#f9f9ff', 'cterm': 189 }
+let s:colors.base15 = { 'gui': ''       , 'cterm': 254 }
+let s:colors.base16 = { 'gui': '#6b6b6b', 'cterm': 242 }
+let s:colors.base17 = { 'gui': '#a3b4ba', 'cterm': 109 }
+let s:colors.base18 = { 'gui': '#c4c7c8', 'cterm': 251 }
+let s:colors.base19 = { 'gui': '#835cad', 'cterm':  97 }
+let s:colors.base20 = { 'gui': '#828282', 'cterm':   8 }
+let s:colors.base21 = { 'gui': '#d9d5d5', 'cterm': 253 }
+let s:colors.base22 = { 'gui': '#969693', 'cterm': 246 }
+let s:colors.base23 = { 'gui': '#282828', 'cterm': 236 }
+let s:colors.base24 = { 'gui': '#3a3c3e', 'cterm': 237 }
+
+" Other colors.
+let s:colors.red     = { 'gui': '#c23127', 'cterm': 124 }
+let s:colors.orange  = { 'gui': '#d26937', 'cterm': 166 }
+let s:colors.yellow  = { 'gui': '#edb443', 'cterm': 214 }
+let s:colors.magenta = { 'gui': '#888ca6', 'cterm': 67  }
+let s:colors.violet  = { 'gui': '#4e5166', 'cterm': 60  }
+let s:colors.blue    = { 'gui': '#195466', 'cterm': 24  }
+let s:colors.cyan    = { 'gui': '#33859E', 'cterm': 44  }
+let s:colors.green   = { 'gui': '#2aa889', 'cterm': 78  }
+
+" Normal modes
+call s:Col('Normal', 'base0', 'base3')
+
+" Line, cursor and so on.
+call s:Col('Cursor', 'base15', 'base14')
+call s:Col('CursorLine', 'base0', 'base24')
+call s:Col('CursorColumn', 'base0', 'base23')
+call s:Col('cursorim', 'base3', 'base1')
+
+" Sign column, line numbers.
+call s:Col('LineNr', 'base8')
+"call s:Col('CursorLineNr', )
+call s:Col('SignColumn', 'base3', 'base5')
+call s:Col('ColorColumn', 'base0', 'base24')
+
+" Visual selection.
+call s:Col('Visual', 'base0', 'base1')
+
+" Easy-to-guess code elements.
+call s:Col('Comment', 'base16')
+call s:Col('String', 'base17')
+call s:Col('Number', 'base18')
+call s:Col('Statement', 'base7')
+call s:Attr('Statement', 'bold')
+call s:Col('Special', 'base4')
+call s:Col('Identifier', 'base4')
+
+" Constants, Ruby symbols.
+call s:Col('Constant', 'base2')
+
+" Some HTML tags (<title>, some <h*>s)
+call s:Col('Title', 'base6', 'base1')
+call s:Attr('Title', 'bold')
+
+" <a> tags.
+call s:Col('Underlined', 'base14', 'base3')
+call s:Attr('Underlined', 'underline')
+
+" Types, HTML attributes, Ruby constants (and class names).
+call s:Col('Type', 'base5')
+call s:Attr('Type', 'bold')
+
+" Stuff like 'require' in Ruby.
+call s:Col('PreProc', 'base19')
+
+" Tildes on the bottom of the page.
+call s:Col('NonText', 'base10')
+
+" TODO and similar tags.
+call s:Col('Todo', 'base13', 'base3')
+
+" The column separating vertical splits.
+call s:Col('VertSplit', 'base3', 'base8')
+call s:Attr('VertSplit', 'bold')
+call s:Col('StatusLineNC', 'base0', 'base8')
+call s:Attr('StatusLineNC', 'bold')
+
+" Matching parenthesis.
+call s:Col('MatchParen', 'base4')
+call s:Attr('MatchParen', 'bold')
+
+" Special keys, e.g. some of the chars in 'listchars'. See ':h listchars'.
+call s:Col('SpecialKey', 'base10')
+call s:Attr('SpecialKey', 'bold')
+
+" Folds.
+call s:Col('Folded', 'base3', 'base2')
+call s:Attr('Folded', 'bold')
+call s:Col('FoldColumn', 'base3', 'base2')
+call s:Attr('FoldColumn', 'bold')
+
+" Searching.
+call s:Col('Search', 'base0', 'base1')
+call s:Attr('IncSearch', 'base0', 'base1')
+
+" Popup menu.
+call s:Col('Pmenu', 'base0', 'base3')
+call s:Col('PmenuSel', 'base0', 'base1')
+call s:Col('PmenuSbar', 'base0', 'base20')
+call s:Col('PmenuThumb', 'base15', 'base2')
+
+" Command line stuff.
+call s:Col('ErrorMsg', 'base11', 'base12')
+call s:Col('ModeMsg', 'base21', 'base3')
+call s:Attr('ModeMsg', 'bold')
+
+" Wild menu.
+" StatusLine determines the color of the non-active entries in the wild menu.
+call s:Col('StatusLine', 'base0', 'base1')
+call s:Attr('StatusLine', 'bold')
+call s:Col('WildMenu', 'base0', 'base2')
+
+" The 'Hit ENTER to continue prompt'.
+"call s:Col('Question', )
+
+" Tab line.
+call s:Col('TabLineSel', 'base0', 'base1')  " the selected tab
+call s:Attr('TabLineSel', 'bold')
+call s:Col('TabLine', 'base3', 'base22')     " the non-selected tabs
+call s:Attr('TabLine', 'bold')
+call s:Col('TabLineFill', 'base3', 'base8') " the rest of the tab line
+call s:Attr('TabLineFill', 'bold')
+
+" Spelling.
+call s:Col('SpellBad', 'base14', 'base3')
+call s:Attr('SpellBad', 'underline')
+call s:Col('SpellCap', 'base14', 'base3')
+call s:Attr('SpellCap', 'underline')
+call s:Col('SpellLocal', 'base14', 'base3')
+call s:Attr('SpellLocal', 'underline')
+call s:Col('SpellRare', 'base14', 'base3')
+call s:Attr('SpellRare', 'underline')
+
+" Diffing.
+call s:Col('DiffAdd', 'base0', 'base23')
+call s:Col('DiffChange', 'base0', 'base1')
+call s:Col('DiffDelete', 'base0', 'base3')
+call s:Col('DiffText', 'base0', 'base1')
+
+" Directories (e.g. netrw).
+call s:Col('Directory', 'base5')
+call s:Attr('Directory', 'bold')
+
+" Plugin =======================================================================
+
+" GitGutter
+call s:Col('GitGutterAdd', 'green', 'base3')
+call s:Col('GitGutterChange', 'yellow', 'base3')
+call s:Col('GitGutterDelete', 'red', 'base3')
+call s:Col('GitGutterChangeDelete', 'orange', 'base3')
+
+" Cleanup =====================================================================
+
+unlet s:colors
+
+" End of gotham-esque settings
+
 hi SpecialComment guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
 hi Typedef guifg=#536991 guibg=NONE guisp=NONE gui=bold ctermfg=60 ctermbg=NONE cterm=bold
-hi Title guifg=#b5b5b5 guibg=#492224 guisp=#492224 gui=bold ctermfg=249 ctermbg=52 cterm=bold
-hi Folded guifg=#192224 guibg=#A1A6A8 guisp=#A1A6A8 gui=bold ctermfg=235 ctermbg=248 cterm=bold
 hi PreCondit guifg=#965b3f guibg=NONE guisp=NONE gui=NONE ctermfg=137 ctermbg=NONE cterm=NONE
 hi Include guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
 hi Float guifg=#A1A6A8 guibg=NONE guisp=NONE gui=NONE ctermfg=248 ctermbg=NONE cterm=NONE
 hi StatusLineNC guifg=#bdae88 guibg=#4b4b4b guisp=#4b4b4b gui=bold ctermfg=144 ctermbg=239 cterm=bold
 "hi CTagsMember -- no settings --
-hi NonText guifg=#5E6C70 guibg=NONE guisp=NONE gui=NONE ctermfg=66 ctermbg=NONE cterm=NONE
 "hi CTagsGlobalConstant -- no settings --
-hi DiffText guifg=NONE guibg=#492224 guisp=#492224 gui=NONE ctermfg=NONE ctermbg=52 cterm=NONE
-hi ErrorMsg guifg=#cfcfcf guibg=#a33202 guisp=#a33202 gui=NONE ctermfg=252 ctermbg=130 cterm=NONE
 "hi Ignore -- no settings --
 hi Debug guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
-hi PMenuSbar guifg=NONE guibg=#828282 guisp=#828282 gui=NONE ctermfg=NONE ctermbg=8 cterm=NONE
-hi Identifier guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
 hi SpecialChar guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
 hi Conditional guifg=#BD9800 guibg=NONE guisp=NONE gui=bold ctermfg=1 ctermbg=NONE cterm=bold
 hi StorageClass guifg=#536991 guibg=NONE guisp=NONE gui=bold ctermfg=60 ctermbg=NONE cterm=bold
-hi Todo guifg=#ff0d0d guibg=#262626 guisp=#262626 gui=NONE ctermfg=196 ctermbg=235 cterm=NONE
-hi Special guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
-hi LineNr guifg=#525252 guibg=NONE guisp=NONE gui=NONE ctermfg=239 ctermbg=NONE cterm=NONE
-hi StatusLine guifg=#bdae88 guibg=#613830 guisp=#613830 gui=bold ctermfg=144 ctermbg=52 cterm=bold
-hi Normal guifg=#bdae88 guibg=#262626 guisp=#262626 gui=NONE ctermfg=144 ctermbg=235 cterm=NONE
 hi Label guifg=#BD9800 guibg=NONE guisp=NONE gui=bold ctermfg=1 ctermbg=NONE cterm=bold
 "hi CTagsImport -- no settings --
-hi PMenuSel guifg=#bdae88 guibg=#492224 guisp=#492224 gui=NONE ctermfg=144 ctermbg=52 cterm=NONE
-hi Search guifg=#bdae88 guibg=#492224 guisp=#492224 gui=NONE ctermfg=144 ctermbg=52 cterm=NONE
 "hi CTagsGlobalVariable -- no settings --
 hi Delimiter guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
-hi Statement guifg=#a26344 guibg=NONE guisp=NONE gui=bold ctermfg=137 ctermbg=NONE cterm=bold
-hi SpellRare guifg=#F9F9FF guibg=#192224 guisp=#192224 gui=underline ctermfg=189 ctermbg=235 cterm=underline
 "hi EnumerationValue -- no settings --
-hi Comment guifg=#6b6b6b guibg=NONE guisp=NONE gui=NONE ctermfg=242 ctermbg=NONE cterm=NONE
 hi Character guifg=#A1A6A8 guibg=NONE guisp=NONE gui=NONE ctermfg=248 ctermbg=NONE cterm=NONE
-hi TabLineSel guifg=#bdae88 guibg=#613830 guisp=#613830 gui=bold ctermfg=144 ctermbg=52 cterm=bold
-hi Number guifg=#c4c7c8 guibg=NONE guisp=NONE gui=NONE ctermfg=251 ctermbg=NONE cterm=NONE
 hi Boolean guifg=#A1A6A8 guibg=NONE guisp=NONE gui=NONE ctermfg=248 ctermbg=NONE cterm=NONE
 hi Operator guifg=#d9d5d5 guibg=NONE guisp=NONE gui=bold ctermfg=253 ctermbg=NONE cterm=bold
-hi CursorLine guifg=NONE guibg=#161616 guisp=#161616 gui=NONE ctermfg=NONE ctermbg=237 cterm=NONE
 "hi Union -- no settings --
-hi TabLineFill guifg=#192224 guibg=#4b4b4b guisp=#4b4b4b gui=bold ctermfg=235 ctermbg=239 cterm=bold
 "hi Question -- no settings --
 hi WarningMsg guifg=#A1A6A8 guibg=#912C00 guisp=#912C00 gui=NONE ctermfg=248 ctermbg=88 cterm=NONE
 hi VisualNOS guifg=#192224 guibg=#F9F9FF guisp=#F9F9FF gui=underline ctermfg=235 ctermbg=189 cterm=underline
-hi DiffDelete guifg=NONE guibg=#241919 guisp=#241919 gui=NONE ctermfg=NONE ctermbg=235 cterm=NONE
-hi ModeMsg guifg=#dedede guibg=#192224 guisp=#192224 gui=bold ctermfg=253 ctermbg=235 cterm=bold
-hi CursorColumn guifg=NONE guibg=#282828 guisp=#282828 gui=NONE ctermfg=NONE ctermbg=236 cterm=NONE
 hi Define guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
 hi Function guifg=#536991 guibg=NONE guisp=NONE gui=bold ctermfg=60 ctermbg=NONE cterm=bold
-hi FoldColumn guifg=#192224 guibg=#A1A6A8 guisp=#A1A6A8 gui=bold ctermfg=235 ctermbg=248 cterm=bold
-hi PreProc guifg=#835cad guibg=NONE guisp=NONE gui=NONE ctermfg=97 ctermbg=NONE cterm=NONE
 "hi EnumerationName -- no settings --
 "hi MarkdownCodeBlock guifg=#dedede guibg=NONE guisp=NONE gui=BOLD
-hi Visual guifg=#bdae88 guibg=#613830 guisp=#613830 gui=NONE ctermfg=144 ctermbg=52 cterm=NONE
 hi MoreMsg guifg=#BD9800 guibg=NONE guisp=NONE gui=bold ctermfg=1 ctermbg=NONE cterm=bold
 hi SpellCap guifg=#F9F9FF guibg=#192224 guisp=#192224 gui=underline ctermfg=189 ctermbg=235 cterm=underline
 hi VertSplit guifg=#262626 guibg=#4b4b4b guisp=#4b4b4b gui=bold ctermfg=235 ctermbg=239 cterm=bold
 hi Exception guifg=#BD9800 guibg=NONE guisp=NONE gui=bold ctermfg=1 ctermbg=NONE cterm=bold
 hi Keyword guifg=#BD9800 guibg=NONE guisp=NONE gui=bold ctermfg=1 ctermbg=NONE cterm=bold
 hi Type guifg=#536991 guibg=NONE guisp=NONE gui=bold ctermfg=60 ctermbg=NONE cterm=bold
-hi DiffChange guifg=NONE guibg=#492224 guisp=#492224 gui=NONE ctermfg=NONE ctermbg=52 cterm=NONE
-hi Cursor guifg=NONE guibg=#b5b5b5 guisp=#b5b5b5 gui=NONE ctermfg=254 ctermbg=131 cterm=NONE
-hi SpellLocal guifg=#F9F9FF guibg=#192224 guisp=#192224 gui=underline ctermfg=189 ctermbg=235 cterm=underline
 hi Error guifg=#A1A6A8 guibg=#912C00 guisp=#912C00 gui=NONE ctermfg=248 ctermbg=88 cterm=NONE
-hi PMenu guifg=#bdae88 guibg=#262626 guisp=#262626 gui=NONE ctermfg=144 ctermbg=235 cterm=NONE
-hi SpecialKey guifg=#5E6C70 guibg=NONE guisp=NONE gui=bold ctermfg=66 ctermbg=NONE cterm=bold
-hi Constant guifg=#A1A6A8 guibg=NONE guisp=NONE gui=NONE ctermfg=248 ctermbg=NONE cterm=NONE
 "hi DefinedName -- no settings --
 hi Tag guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
-hi String guifg=#a3b4ba guibg=NONE guisp=NONE gui=NONE ctermfg=109 ctermbg=NONE cterm=NONE
-hi PMenuThumb guifg=#e6e6e6 guibg=#a4a6a8 guisp=#a4a6a8 gui=NONE ctermfg=254 ctermbg=248 cterm=NONE
-hi MatchParen guifg=#BD9800 guibg=NONE guisp=NONE gui=bold ctermfg=1 ctermbg=NONE cterm=bold
 hi LocalVariable guifg=#efae87 guibg=NONE guisp=NONE gui=bold ctermfg=209 ctermbg=NONE cterm=bold
 hi Repeat guifg=#bd9700 guibg=NONE guisp=NONE gui=bold ctermfg=1 ctermbg=NONE cterm=bold
-hi SpellBad guifg=#F9F9FF guibg=#192224 guisp=#192224 gui=underline ctermfg=189 ctermbg=235 cterm=underline
 "hi CTagsClass -- no settings --
-hi Directory guifg=#536991 guibg=NONE guisp=NONE gui=bold ctermfg=60 ctermbg=NONE cterm=bold
 hi Structure guifg=#536991 guibg=NONE guisp=NONE gui=bold ctermfg=60 ctermbg=NONE cterm=bold
 hi Macro guifg=#BD9800 guibg=NONE guisp=NONE gui=NONE ctermfg=1 ctermbg=NONE cterm=NONE
-hi Underlined guifg=#F9F9FF guibg=#192224 guisp=#192224 gui=underline ctermfg=189 ctermbg=235 cterm=underline
-hi DiffAdd guifg=NONE guibg=#193224 guisp=#193224 gui=NONE ctermfg=NONE ctermbg=236 cterm=NONE
-hi TabLine guifg=#192224 guibg=#969693 guisp=#969693 gui=bold ctermfg=235 ctermbg=246 cterm=bold
-hi cursorim guifg=NONE guibg=#b5b5b5 guisp=#b5b5b5 gui=NONE ctermfg=235 ctermbg=52 cterm=NONE
-hi colorcolumn guifg=NONE guibg=#3a3c3e guisp=#3a3c3e gui=NONE ctermfg=NONE ctermbg=237 cterm=NONE
 "hi clear -- no settings --

--- a/colors/Revolution.vim
+++ b/colors/Revolution.vim
@@ -223,6 +223,9 @@ call s:Col('GitGutterChange', 'yellow', 'base3')
 call s:Col('GitGutterDelete', 'red', 'base3')
 call s:Col('GitGutterChangeDelete', 'orange', 'base3')
 
+" vim-better-whitespace
+call s:Col('ExtraWhitespace', 'violet', 'yellow')
+
 " Cleanup =====================================================================
 
 unlet s:colors

--- a/colors/Revolution.vim
+++ b/colors/Revolution.vim
@@ -1,14 +1,4 @@
-"" Vim color file - Revolution
-"set background=dark
-"if version > 580
-	"hi clear
-	"if exists("syntax_on")
-		"syntax reset
-	"endif
-"endif
-
-"set t_Co=256
-"let g:colors_name = "Revolution"
+"this is using the vim-gotham style of setting most colors
 
 hi clear
 if exists('syntax on') | syntax reset | endif
@@ -23,7 +13,11 @@ endfunction
 function! s:AddGroundValues(accumulator, ground, color)
   let new_list = a:accumulator
   for [where, value] in items(a:color)
-    call add(new_list, where . a:ground . '=' . value)
+    if value == "NONE" || value == "none" || value == ""
+      call add(new_list, where . a:ground . '= NONE')
+    else
+      call add(new_list, where . a:ground . '=' . value)
+    endif
   endfor
 
   return new_list
@@ -76,7 +70,7 @@ let s:colors.base11 = { 'gui': '#cfcfcf', 'cterm': 252 }
 let s:colors.base12 = { 'gui': '#a33202', 'cterm': 130 }
 let s:colors.base13 = { 'gui': '#ff0d0d', 'cterm': 196 }
 let s:colors.base14 = { 'gui': '#f9f9ff', 'cterm': 189 }
-let s:colors.base15 = { 'gui': ''       , 'cterm': 254 }
+let s:colors.base15 = { 'gui': 'NONE'   , 'cterm': 254 }
 let s:colors.base16 = { 'gui': '#6b6b6b', 'cterm': 242 }
 let s:colors.base17 = { 'gui': '#a3b4ba', 'cterm': 109 }
 let s:colors.base18 = { 'gui': '#c4c7c8', 'cterm': 251 }
@@ -97,19 +91,20 @@ let s:colors.blue    = { 'gui': '#195466', 'cterm': 24  }
 let s:colors.cyan    = { 'gui': '#33859E', 'cterm': 44  }
 let s:colors.green   = { 'gui': '#2aa889', 'cterm': 78  }
 
+let s:colors.none    = { 'gui': 'NONE', 'cterm': 'NONE'  }
+
 " Normal modes
 call s:Col('Normal', 'base0', 'base3')
 
 " Line, cursor and so on.
 call s:Col('Cursor', 'base15', 'base14')
-call s:Col('CursorLine', 'base0', 'base24')
+call s:Col('CursorLine', 'none', 'base24')
 call s:Col('CursorColumn', 'base0', 'base23')
 call s:Col('cursorim', 'base3', 'base1')
 
 " Sign column, line numbers.
 call s:Col('LineNr', 'base8')
-"call s:Col('CursorLineNr', )
-call s:Col('SignColumn', 'base3', 'base5')
+call s:Col('SignColumn', 'base3', 'base3')
 call s:Col('ColorColumn', 'base0', 'base24')
 
 " Visual selection.
@@ -170,7 +165,7 @@ call s:Attr('FoldColumn', 'bold')
 
 " Searching.
 call s:Col('Search', 'base0', 'base1')
-call s:Attr('IncSearch', 'base0', 'base1')
+call s:Col('IncSearch', 'base0', 'base1')
 
 " Popup menu.
 call s:Col('Pmenu', 'base0', 'base3')


### PR DESCRIPTION
Autoload for airline theme now allows Revolution to properly color the
status bar without the need for AirlineRefresh.  Inspired by an issue
encountered with vim-daylight.

Note that the autoload file used here is just the dark.vim autoload from vim-airline.  These colors can be changed larger.  For now, it just enforces a colored airline bar.
